### PR TITLE
The username and password can be entered for Shelly devices with protected web interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,5 @@
 [![license](https://img.shields.io/badge/license-MPL--2.0-blue.svg)](LICENSE)
 
 Connect your shelly devices.
+
+Add the `username` and the `password` of a user with Shelly device access.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Shelly adapter
 
+Add the `username` and the `password` of a user with Shelly device access. 
+
 [![build](https://github.com/tim-hellhake/esphome-adapter/workflows/Build/badge.svg)](https://github.com/tim-hellhake/esphome-adapter/actions?query=workflow:Build)
 [![dependencies](https://david-dm.org/tim-hellhake/shelly-adapter.svg)](https://david-dm.org/tim-hellhake/shelly-adapter)
 [![devDependencies](https://david-dm.org/tim-hellhake/shelly-adapter/dev-status.svg)](https://david-dm.org/tim-hellhake/shelly-adapter?type=dev)

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "id": "shelly-adapter",
   "name": "Shelly",
   "short_name": "Shelly",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Connect your shelly devices",
   "homepage_url": "https://github.com/tim-hellhake/shelly-adapter#readme",
   "license": "MPL-2.0",
@@ -14,6 +14,21 @@
       "strict_min_version": "0.10.0",
       "strict_max_version": "*",
       "primary_type": "adapter"
+    }
+  },
+  "options": {
+    "schema": {
+      "type": "object",
+      "properties": {
+        "username": {
+          "type": "string",
+          "title": "The username"
+        },
+        "password": {
+          "type": "string",
+          "title": "The password"
+        }
+      }
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "shelly-adapter",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -205,9 +205,9 @@
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
     "qs": {
-      "version": "6.9.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.1.tgz",
-      "integrity": "sha512-Cxm7/SS/y/Z3MHWSxXb8lIFqgqBowP5JMlTUFyJN88y0SGQhVmZnqFK/PeuMX9LzUyWsqqhNxIyg0jlzq946yA=="
+      "version": "6.9.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.3.tgz",
+      "integrity": "sha512-EbZYNarm6138UKKq46tdx08Yo/q9ZhFoAXAI1meAFd2GtbRDhbZY2WQSICskT0c5q99aFzLG1D4nvTk9tqfXIw=="
     },
     "readable-stream": {
       "version": "2.3.7",
@@ -241,9 +241,9 @@
       "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
     },
     "shellies": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/shellies/-/shellies-0.16.0.tgz",
-      "integrity": "sha512-KgG+FSNNaz1FblKGqMWmyMzernmbhHdp10mH1C0+MLHXizyXDfAZJiyTfyNkwfXO6FtSwURgfqTYApjTjEwxWA==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/shellies/-/shellies-0.18.0.tgz",
+      "integrity": "sha512-U8rGlAjh+T+IjWNPLKUqLIZflJxTUg/3mZK4vDQ4YDkJgghKJjpNIGMulreO5DLD9ENECr59WiYgbu6vJPRdWA==",
       "requires": {
         "coap": "^0.22.0",
         "colors": "^1.3.3",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "exec": "{nodeLoader} {path}"
   },
   "dependencies": {
-    "shellies": "^0.16.0"
+    "shellies": "^0.18.0"
   },
   "devDependencies": {
     "typescript": "^3.8.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "shelly-adapter",
   "display_name": "Shelly",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Connect your shelly devices",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -40,7 +40,20 @@
       "max": 2
     },
     "plugin": true,
-    "exec": "{nodeLoader} {path}"
+    "exec": "{nodeLoader} {path}",
+    "schema": {
+      "type": "object",
+      "properties": {
+        "username": {
+          "type": "string",
+          "title": "The username"
+        },
+        "password": {
+          "type": "string",
+          "title": "The password"
+        }
+      }
+    }
   },
   "dependencies": {
     "shellies": "^0.18.0"

--- a/src/shellies.d.ts
+++ b/src/shellies.d.ts
@@ -7,6 +7,7 @@
 declare module 'shellies' {
     function on(type: 'discover', listener: (device: Shelly) => void): void;
     function start(): any;
+    function setAuthCredentials(username: string, password: string): void;
 
     class Shelly {
         public id: string;

--- a/src/shelly-adapter.ts
+++ b/src/shelly-adapter.ts
@@ -15,7 +15,21 @@ export class ShellyAdapter extends Adapter {
         addonManager.addAdapter(this);
 
         const {
+            username,
+            password,
         } = manifest.moziot.config;
+
+        if (!username) {
+            console.warn('Please specify username in the config');
+        }
+
+        if (!password) {
+            console.warn('Please specify password in the config');
+        }
+
+        if (username && password) {
+            shellies.setAuthCredentials(username, password);
+        }
 
         shellies.on('discover', device => {
             console.log(`Discovered new ${device.constructor.name} with id ${device.id}`);


### PR DESCRIPTION
My shellies are secured with username/password.
The node-shellies project supports credentials, so I created this pull request.