### PR TITLE
Add tilt property to shelly door/window 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "lib/switch-property.js",
     "lib/temperature-property.js",
     "lib/roller-position-property.js",
-    "lib/vibration-property.js"
+    "lib/vibration-property.js",
+    "lib/tilt-property.js"
   ],
   "dependencies": {
     "shellies": "^1.5.0"

--- a/src/shellies.d.ts
+++ b/src/shellies.d.ts
@@ -27,5 +27,6 @@ declare module 'shellies' {
         public state?: boolean;
         public vibration?: boolean;
         public illuminance?: number;
+        public tilt?: number;
     }
 }

--- a/src/shelly-device.ts
+++ b/src/shelly-device.ts
@@ -5,7 +5,7 @@
  */
 
 import {Action, Adapter, Device, Property} from 'gateway-addon';
-import {Action as ActionSchema, PropertyValue} from 'gateway-addon/lib/schema';
+import {Action as ActionSchema, Any} from 'gateway-addon/lib/schema';
 import {Shelly} from 'shellies';
 import {debug} from './log';
 import {TemperatureProperty} from './temperature-property';
@@ -13,7 +13,7 @@ import {TemperatureProperty} from './temperature-property';
 export class ShellyDevice extends Device {
     private callbacks: { [key: string]: () => void } = {};
 
-    private propertyByAlias: Record<string, Property<PropertyValue>> = {};
+    private propertyByAlias: Record<string, Property<Any>> = {};
 
     constructor(adapter: Adapter, device: Shelly) {
       super(adapter, device.id);
@@ -23,7 +23,7 @@ export class ShellyDevice extends Device {
 
       device.on(
         'change',
-        (prop: string, newValue: PropertyValue, oldValue: PropertyValue) => {
+        (prop: string, newValue: Any, oldValue: Any) => {
           debug(
             `${device.id} ${prop} changed from ${oldValue} to ${newValue}`);
 
@@ -46,7 +46,7 @@ export class ShellyDevice extends Device {
     }
 
     protected addPropertyWithAlias(
-      shellyProperty: string, property: Property<PropertyValue>): void {
+      shellyProperty: string, property: Property<Any>): void {
       this.addProperty(property);
       this.propertyByAlias[shellyProperty] = property;
     }

--- a/src/shelly-door-window-2.ts
+++ b/src/shelly-door-window-2.ts
@@ -12,6 +12,7 @@ import {OpenProperty} from './open-property';
 import {ShellyDevice} from './shelly-device';
 import {TemperatureProperty} from './temperature-property';
 import {VibrationProperty} from './vibration-property';
+import {TiltProperty} from './tilt-property';
 
 export class ShellyDoorWindow2 extends ShellyDevice {
   constructor(adapter: Adapter, device: Shelly) {
@@ -53,6 +54,13 @@ export class ShellyDoorWindow2 extends ShellyDevice {
 
     if (typeof device.illuminance === 'number') {
       illuminance.setCachedValueAndNotify(device.illuminance);
+    }
+
+    const tilt = new TiltProperty(this, 'tilt', 'Tilt Angle');
+    this.addProperty(tilt);
+
+    if (typeof device.tilt === 'number') {
+      tilt.setCachedValueAndNotify(device.tilt);
     }
   }
 }

--- a/src/tilt-property.ts
+++ b/src/tilt-property.ts
@@ -1,0 +1,22 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.*
+ */
+
+import {Property} from 'gateway-addon';
+import {ShellyDevice} from './shelly-device';
+
+export class TiltProperty extends Property<number> {
+  constructor(device: ShellyDevice, name: string, title: string) {
+    super(device, name, {
+      type: 'integer',
+      minimum: 0,
+      maximum: 180,
+      title: title,
+      description: 'Shelly tilt degrees',
+      unit: '°',
+      readOnly: true,
+    });
+  }
+}


### PR DESCRIPTION
Also drive-by fixes `shelly-device.ts` to use things that exist maybe. Tested with my dw2 that the property actually exists and works. I reverted the fix to install `@types/ws` because that would've been a big `package-lock.json` change and I'm sure you can deal with that yourself.